### PR TITLE
Issue #39 - examples of showing the chosen type.

### DIFF
--- a/config/views.view.masonry_views.yml
+++ b/config/views.view.masonry_views.yml
@@ -562,22 +562,25 @@ display:
             article: article
             story: story
           group: 1
-          exposed: false
+          exposed: true
           expose:
-            operator_id: ''
-            label: ''
+            operator_id: type_op
+            label: 'Content type'
             description: ''
             use_operator: false
-            operator: ''
+            operator: type_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: ''
+            identifier: type
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            reduce: false
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: true
           is_grouped: false
           group_info:
             label: ''
@@ -610,7 +613,18 @@ display:
             label: ''
           granularity: second
       title: 'Masonry Views'
-      header: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content: '{{ type }} is the chosen content type'
+          plugin_id: text_custom
       footer: {  }
       empty: {  }
       relationships:
@@ -640,6 +654,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -661,6 +676,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions

--- a/web/themes/custom/ucpe_theme/templates/views/views-view--masonry-views--block-1.html.twig
+++ b/web/themes/custom/ucpe_theme/templates/views/views-view--masonry-views--block-1.html.twig
@@ -1,0 +1,98 @@
+{#
+/**
+ * @file
+ * Default theme implementation for main view template.
+ *
+ * Available variables:
+ * - attributes: Remaining HTML attributes for the element.
+ * - css_name: A css-safe version of the view name.
+ * - css_class: The user-specified classes names, if any.
+ * - header: The optional header.
+ * - footer: The optional footer.
+ * - rows: The results of the view query, if any.
+ * - empty: The content to display if there are no rows.
+ * - pager: The optional pager next/prev links to display.
+ * - exposed: Exposed widget form/info to display.
+ * - feed_icons: Optional feed icons to display.
+ * - more: An optional link to the next page of results.
+ * - title: Title of the view, only used when displaying in the admin preview.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the view title.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the view title.
+ * - attachment_before: An optional attachment view to be displayed before the
+ *   view content.
+ * - attachment_after: An optional attachment view to be displayed after the
+ *   view content.
+ * - dom_id: Unique id for every view being printed to give unique class for
+ *   JavaScript.
+ *
+ * @ingroup templates
+ *
+ * @see template_preprocess_views_view()
+ */
+#}
+{%
+  set classes = [
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if title %}
+    {{ title }}
+  {% endif %}
+  {{ title_suffix }}
+  {% if header %}
+    <div class="view-header">
+      {{ header }}
+    </div>
+  {% endif %}
+  {% if exposed %}
+    <div class="view-filters form-group">
+      {{ exposed }}
+    </div>
+  {% endif %}
+  {% if attachment_before %}
+    <div class="attachment attachment-before">
+      {{ attachment_before }}
+    </div>
+  {% endif %}
+
+  {% if rows %}
+    <div class="view-content">
+      The current value of the Type dropdown is: {{ exposed.type['#options'][exposed.type['#value']] }}
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    <div class="view-empty">
+      {{ empty }}
+    </div>
+  {% endif %}
+
+  {% if pager %}
+    {{ pager }}
+  {% endif %}
+  {% if attachment_after %}
+    <div class="attachment attachment-after">
+      {{ attachment_after }}
+    </div>
+  {% endif %}
+  {% if more %}
+    {{ more }}
+  {% endif %}
+  {% if footer %}
+    <div class="view-footer">
+      {{ footer }}
+    </div>
+  {% endif %}
+  {% if feed_icons %}
+    <div class="feed-icons">
+      {{ feed_icons }}
+    </div>
+  {% endif %}
+</div>

--- a/web/themes/custom/ucpe_theme/ucpe_theme.theme
+++ b/web/themes/custom/ucpe_theme/ucpe_theme.theme
@@ -6,3 +6,9 @@
  *
  * Place your custom PHP code in this file.
  */
+function ucpe_theme_theme_suggestions_views_view_alter(array &$suggestions, array $variables) {
+  $current_view = $variables['view']->current_display;
+  $current_id = $variables['view']->id();
+  $suggestions[] = 'views_view__' . $current_id;
+  $suggestions[] = 'views_view__' . $current_id . '__' . $current_view;
+}


### PR DESCRIPTION
@Stacey1979 Here's a couple of ways you might alter a view to show which values were chosen in the dropdown filter. I enabled a visible exposed "Content Type" dropdown to demonstrate -- not sure if this is the right view. But here's the output:
<img width="593" alt="Screen Shot 2020-07-22 at 9 30 04 AM" src="https://user-images.githubusercontent.com/999525/88203567-e3ab2f80-cbfe-11ea-854e-816f109785da.png">

The top value that says "Case Study is the chosen content type" is using the value of the field "type" on the first result, as it stands to reason that the value of that field will match the value that you chose. Here's what that looks like in the backend:
<img width="1328" alt="Screen Shot 2020-07-22 at 10 02 32 AM" src="https://user-images.githubusercontent.com/999525/88206045-85804b80-cc02-11ea-926d-5bf4a0f44bb7.png">


This works as long as there can only be one "Type", but might not work if your node could have multiple "Types" (if it were a Term reference or something like that).

The bottom value is added by overwriting the Twig template in this line:
```
The current value of the Type dropdown is: {{ exposed.type['#options'][exposed.type['#value']] }}
```

That is more technically what you're looking for: Get the value of the "Type" dropdown, then print out its option label. 

That might change a bit with BEF.